### PR TITLE
Fix doc.rs build failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,18 @@ language: rust
 
 matrix:
   fast_finish: true
+
   include:
     - rust: nightly
-      env: 
-        - TARGET=armv7-unknown-linux-gnueabihf
-        - CFLAGS='-mfpu=neon-fp-armv8 -mfloat-abi=hard -march=armv8-a -Wall -O3 -nostartfiles -ffreestanding -mtune=cortex-a53'
-        - RUSTFLAGS='-C target-cpu=cortex-a53 -C target-feature=+a53,+fp-armv8,+v8,+vfp3,+d16,+thumb2,+neon'
 
-script:
-  cargo build --target armv7-unknown-linux-gnueabihf --verbose
+script: ./travis-build.sh
 
 install:
+# install cross compiler toolchain
   - sudo apt-get install gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
+# install cargo xbuild to proper cross compile  
+  - cargo install cargo-xbuild
+# add the build target used for Raspbarry Pi targeting builds
   - rustup target add armv7-unknown-linux-gnueabihf
+  - rustup component add rust-src
+  - sudo chmod ugo+x ./travis-build.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,7 +7,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ruspiro-boot"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "cc 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,20 @@
 [package]
 name = "ruspiro-boot"
 authors = ["André Borrmann <pspwizard@gmx.de>"]
-version = "0.1.0" # remember to update html_root_url
+version = "0.1.1" # remember to update html_root_url
 description = "The crate provides baremetal boot code for the Raspberry Pi 3 to conviniently start your custom kernel within the Rust environment without the need to dangle with all the initial setup like stack pointers, getting MMU setup or getting all cores kicked off for processing."
 license = "Apache-2.0"
-repository = "https://github.com/RusPiRo/ruspiro-boot/tree/v.0.1.0"
-documentation = "https://docs.rs/ruspiro-boot/0.1.0"
+repository = "https://github.com/RusPiRo/ruspiro-boot/tree/v.0.1.1"
+documentation = "https://docs.rs/ruspiro-boot/0.1.1"
 readme = "README.md"
 keywords = ["RusPiRo", "raspberrypi", "boot", "baremetal", "multicore"]
 categories = ["no-std", "embedded"]
 edition = "2018"
+
+[badges]
+travis-ci = { repository = "RusPiRo/ruspiro-boot", branch = "master" }
+maintenance = { status = "actively-developed" }
+
 
 [lib]
 
@@ -23,3 +28,11 @@ default = ["ruspiro_pi3"]
 ruspiro_pi3 = []
 with_panic = []
 with_exception = []
+
+[package.metadata.docs.rs]
+all-features = true
+default-target = "armv7-unknown-linux-gnueabihf"
+rustc-args = [
+    "-C target-cpu=cortex-a53",
+    "-C target-feature=+a53,+fp-armv8,+v8,+vfp3,+d16,+thumb2,+neon"
+    ]

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To use this crate simply add the following lines to your ``Cargo.toml`` file:
 (hint: git dependency as long as the crate is not registered at crates.io)
 ```
 [dependencies]
-ruspiro-boot = { version = "0.1.0", features = ["with_panic", "with_exception"] }
+ruspiro-boot = { version = "0.1.1", features = ["with_panic", "with_exception"] }
 ```
 The feature ``ruspiro_pi3`` is active by default and need not to be passed
 The feature ``with_panic`` will ensure that a default panic handler is implemented.
@@ -24,19 +24,16 @@ The feature ``with_exception`` will ensure that a default exception and interrup
 
 To successfully link this crate it is **highly recomended** to use the linker script [link.ld](link.ld) for this step. This file defines all the necessary linker sections and symbols to allow this crate taking responsibility on the whole boot sequence of the Raspberry Pi in 32bit baremetal mode.
 
-To refer to the linker script create a ``.cargo`` folder in your project root and add a file named ``config`` (without any file extension) to it. The file content shall be as follows:
+To refer to the linker script either pass a ``RUSTFLAG`` parameter ``-C link-arg=-T<path_to_the_link_file>/link.ld`` to your build or create a ``.cargo`` folder in your project root and add a file named ``config`` (without any file extension) to it. Add the following ``link-arg`` parameter to the file.
 ```
 [target.armv7-unknown-linux-gnueabihf]
-linker = "arm-eabi-gcc"
 rustflags = [
     "-C", "link-arg=-T<path_to_the_link_file>/link.ld",
-    "-C", "target-cpu=cortex-a53",
-    "-C", "target-feature=+a53,+fp-armv8,+v8,+vfp3,+d16,+thumb2,+neon",
-    "-C", "opt-level=3",
-    "-C", "debuginfo=0"
 ]
 ```
 Just replace the ``<path_to_the_link_file>`` with the path where you stored the linker script file of this crate.
+When working with the [``ruspiro-sdk``](https://github.com/RusPiRo/ruspiro-sdk) you may want to check the different example
+Scenarios where this crates is used and how it is successfully build using a make file.
 
 
 ## License

--- a/Xargo.toml
+++ b/Xargo.toml
@@ -1,4 +1,0 @@
-# define specific additional dependencies in addition to the rust core crate when running xargo to create documentation
-# the release build done with cargo xbuild does not need this to properly compile and link all used additional crates
-[target.armv8-ruspiro.dependencies]
-alloc = {}

--- a/build.rs
+++ b/build.rs
@@ -16,14 +16,23 @@ fn main() {
     if build_pi3 {
         cc::Build::new()
             .file("src/asm/boot.s")
+            .flag("-march=armv8-a")
+            .flag("-mfpu=neon-fp-armv8")
+            .flag("-mfloat-abi=hard")
             .compile("boot");
 
         cc::Build::new()
             .file("src/asm/irqtrampoline.s")
+            .flag("-march=armv8-a")
+            .flag("-mfpu=neon-fp-armv8")
+            .flag("-mfloat-abi=hard")
             .compile("irqtrampoline");
         
         cc::Build::new()
             .file("src/asm/mmu.s")
+            .flag("-march=armv8-a")
+            .flag("-mfpu=neon-fp-armv8")
+            .flag("-mfloat-abi=hard")
             .compile("mmu");
     }
 }

--- a/src/asm/mmu.s
+++ b/src/asm/mmu.s
@@ -19,10 +19,10 @@ __setup_ttlb:             // N   A
 	mov		r1, #0x0     // 1  S1TEX1 P    X B10
 	                     // 9   5   1  8  5 3  0
 //ldr		r2, =0x90C0E // 10010000110000001110 --> shareable, outer/inner write back no allocate
-ldr		r2, =0x90C0A     // 10010000110000001010 --> shareable, outer/inner write through no allocate on write
+//ldr		r2, =0x90C0A     // 10010000110000001010 --> shareable, outer/inner write through no allocate on write
 //    ldr	r2, =0x91C0E // 10010001110000001110 --> shareable, outer/inner write back, allocate on write
 //ldr		r2, =0x91C02 // 10010001110000000010 --> (normal, outer/inner non cacheable, shared)	
-	ldr     r2,          =0b00000000110000011110
+	ldr     r2,          =0b00000000110000011110 //--> shareable, outer/inner write back, allocate on write
 	ldr		r4, =0x4FC0
 
 .loop1:						// write 4096 entries to MMUTable

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
  * Author: André Borrmann 
  * License: Apache License 2.0
  **********************************************************************************************************************/
-#![doc(html_root_url = "https://docs.rs/ruspiro-boot/0.1.0")]
+#![doc(html_root_url = "https://docs.rs/ruspiro-boot/0.1.1")]
 #![no_std]
 
 #![feature(asm)]        // needed to be able to use inline assembly
@@ -35,7 +35,7 @@
 //! }
 //! ```
 //! As the boot routines provided by this crate depend on some external defined linker symbols the binary should always
-//! be linked with this [linker script](https://github.com/RusPiRo/ruspiro-boot/blob/v0.1.0/link.ld)
+//! be linked with this [linker script](https://github.com/RusPiRo/ruspiro-boot/blob/v0.1.1/link.ld)
 //! 
 //! The binary would not need any further dependencies to compile and link into a kernel image file that could be put
 //! onto a Raspberry Pi SD card and executed as baremetal kernel.

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -10,18 +10,19 @@
 //! This module provides macros to ease the assignment of custom functions for the entypoints into the code provided by
 //! the consumer of this crate
 
-/// Define a macro that enables easy setting of a custom entry point function to be used once the mandatory
+/// Use this macro to define the your custom one-time-initialization entry point function to be used once the mandatory
 /// boot process has finished and the processing is handed over to the high level rust code. As each core will come
 /// come alive **one after another**, this function is called with the core it's running on. The next core comes alive
 /// after the actual one finished processing this function
 /// 
 /// # Example
-/// 
+/// ```
 /// come_alive_with!(my_init_once);
 /// 
 /// fn my_init_once(core: u32) {
 ///     // do any one-time initialization here....
 /// }
+/// ```
 /// 
 #[macro_export]
 macro_rules! come_alive_with {
@@ -37,17 +38,18 @@ macro_rules! come_alive_with {
     };
 }
 
-/// Define a macro that enables easy setting of a custom entry point function to be used for the processing
+/// Use this macro to define the never-returning processing entry point function to be used for the processing
 /// after all one-time initializations have been done. This function is intended to never return and is executed
 /// on each core individually. Therefore this function is called with the core number it's running on.
 /// 
 /// # Example
-/// 
+/// ```
 /// run_with!(my_processing);
 /// 
 /// fn my_processing(core: u32) -> ! {
-///     loop { } // safely hang here as we should never return. Real processing should go inside the loop.
+///     loop { } // safely hang here as we should never return.
 /// }
+/// ```
 /// 
 #[macro_export]
 macro_rules! run_with {

--- a/src/stubs.rs
+++ b/src/stubs.rs
@@ -6,6 +6,7 @@
  **********************************************************************************************************************/
 
 //! # Linker Stubs
+//! 
 //! The module provides stub implementations of functions needed by the linker even in baremetal environment. As
 //! the final binary is not intended to run a real OS those functions typically have no content.
 

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -ev
+
+export CFLAGS='-mfpu=neon-fp-armv8 -mfloat-abi=hard -march=armv8-a -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53'
+export RUSTFLAGS='-C linker=arm-linux-gnueabihf-gcc -C target-cpu=cortex-a53 -C target-feature=+a53,+fp-armv8,+v8,+vfp3,+d16,+thumb2,+neon -C link-arg=-nostartfiles -C opt-level=3 -C debuginfo=0'
+
+cargo xbuild --target armv7-unknown-linux-gnueabihf --verbose --release --all


### PR DESCRIPTION
Add compile flags to the build.rs script to ensure proper build even on doc.rs generated builds where no other CFLAGS could be passed.