### PR TITLE
fix linker script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## :strawberry: v0.4.1
+
+  Fxing the linker script. Some of the section requires re-ordering to properly link with new versions of LLVM/LLD used in the current rustc version.
+
+- ### :detective: Fixes
+
+  - re-order sections in the linker script file
+
 ## :peach: v0.4.0
 
   Refactoring the crate into a more lightweight 64Bit only version. This now provides a tailormade lean implementation to boot up the Raspberry Pi either in *multicore* or *singlecore* setup. The boot sequence hands processing to an entry functions that needs to be implemented by the user of this crate. The implementer of this entry point function does have now full freedom where to go from here. As part of the boot sequence there is nomore a forced setup of the MMU or any other peripheral.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,7 +17,7 @@ dependencies = [
 
 [[package]]
 name = "ruspiro-boot"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "cc",
  "ruspiro-cache",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ruspiro-boot"
 authors = ["André Borrmann <pspwizard@gmx.de>"]
-version = "0.4.0" # remember to update html_root_url
+version = "0.4.1" # remember to update html_root_url
 description = """
 Bare metal boot strapper code for the Raspberry Pi 3 to conviniently start a custom kernel within the Rust environment
 without the need to deal with all the initial setup like stack pointers, switch to the appropriate exeption level and getting all cores kicked off for processing of code compiled from Rust.

--- a/link64.ld
+++ b/link64.ld
@@ -19,9 +19,6 @@ SECTIONS
 	    
     .text : { KEEP(*(.text.boot)) *(.text*) }
     .rodata : { *(.rodata*) }
-	PROVIDE(_data = .);
-    .data : { *(.data*) }
-    
 	. = ALIGN(8);
     .init_array : {
 		__init_start = .;
@@ -29,7 +26,6 @@ SECTIONS
 		*(.init_array.*)
 		__init_end = .;
 	}
-    
     /* bss section, contains all static variables of the c code */
     .bss : { 
     	__bss_start__ = .;
@@ -37,6 +33,8 @@ SECTIONS
     	*(COMMON)
     	__bss_end__ = .;
     }
+	PROVIDE(_data = .);
+    .data : { *(.data*) }
 
 	/* fill the binary to always have an aligned binary size - needed for the bootloader on RPi to work properly */
 	.fill : {


### PR DESCRIPTION
Linking with current rustc (nightly) versions using a more recent llvm/lld failed with the error:
```
rust-lld: error: section: .init_array is not contiguous with other relro sections
```

Re-Ordering the sections in the link64.ld solved this issue.