### PR TITLE
Update linker script to discard specific sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## :strawberry: v0.4.2
+
+  Prepare the boot crate to be used in the custom test framework as well.
+
+- ### :bulb: Features
+
+  - introduce a new feature `test` to control compilation when the boot crate is used for the custon test framework.
+
 ## :strawberry: v0.4.1
 
   Fxing the linker script. Some of the section requires re-ordering to properly link with new versions of LLVM/LLD used in the current rustc version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## :strawberry: v0.4.2
 
-  Prepare the boot crate to be used in the custom test framework as well.
+Adjust the linker script to discard specific sections. With the sections in place build on travis for the custom unit test framework lead to a wrong start memory address for the kernel used with *QEMU*.
 
-- ### :bulb: Features
+- ### :detective: Fixes
 
-  - introduce a new feature `test` to control compilation when the boot crate is used for the custon test framework.
+  - Discard `*.note.gnu*` section in the linker script.
 
 ## :strawberry: v0.4.1
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ ruspiro-cache = "0.4"
 [features]
 ruspiro_pi3 = [ ]
 multicore = [ ]
-test = [ ]
 
 # ensure the required features of the crate are active for the doc.rs build
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ruspiro-boot"
 authors = ["André Borrmann <pspwizard@gmx.de>"]
-version = "0.4.1" # remember to update html_root_url
+version = "0.4.2" # remember to update html_root_url
 description = """
 Bare metal boot strapper code for the Raspberry Pi 3 to conviniently start a custom kernel within the Rust environment
 without the need to deal with all the initial setup like stack pointers, switch to the appropriate exeption level and getting all cores kicked off for processing of code compiled from Rust.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ ruspiro-cache = "0.4"
 [features]
 ruspiro_pi3 = [ ]
 multicore = [ ]
+test = [ ]
 
 # ensure the required features of the crate are active for the doc.rs build
 [package.metadata.docs.rs]

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Feature          | Purpose
 -----------------|--------------------------
 `multicore`      | Compiles the multi-core version of the crate, kicking off all 4 cores of the Raspberry Pi.
 `ruspiro_pi3`    | This is passed to the dependend crates to ensure they will be build properly for this target device.
-`test`           | Use this feature only if the crate is used as *dev-dependency* and is intended to be used to boot the custom test framework test runner.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -16,10 +16,11 @@ both architectures and the execution is tested on a Raspberry Pi 3 B+.
 
 ## Features
 
-Feature            | Purpose
--------------------|--------------------------
-``multicore``      | Compiles the multi-core version of the crate, kicking off all 4 cores of the Raspberry Pi.
-``ruspiro_pi3``    | This is passed to the dependend crates to ensure they will be build properly for this target device.
+Feature          | Purpose
+-----------------|--------------------------
+`multicore`      | Compiles the multi-core version of the crate, kicking off all 4 cores of the Raspberry Pi.
+`ruspiro_pi3`    | This is passed to the dependend crates to ensure they will be build properly for this target device.
+`test`           | Use this feature only if the crate is used as *dev-dependency* and is intended to be used to boot the custom test framework test runner.
 
 ## Usage
 

--- a/link64.ld
+++ b/link64.ld
@@ -68,4 +68,9 @@ SECTIONS
 	__heap_start = .;
     /* heap end is defined by the usage split of arm/gpu - set this to a fixed value for the time beeing */
 	__heap_end = 0x3E000000;
+
+	/DISCARD/ :
+	{
+		*(.note.gnu*)
+	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,6 @@ extern "C" {
 /// `come_alive_with!` and `run_with!`. This entry point is assumed to be always called
 /// in EL1(aarch64) or SVC(aarch32) mode
 ///
-#[cfg(not(feature = "test"))]
 #[export_name = "__rust_entry"]
 unsafe fn __rust_entry(core: u32) -> ! {
     // first step before going any further is to clean the L1 cache to ensure there

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,7 @@ extern "C" {
 /// `come_alive_with!` and `run_with!`. This entry point is assumed to be always called
 /// in EL1(aarch64) or SVC(aarch32) mode
 ///
+#[cfg(not(feature = "test"))]
 #[export_name = "__rust_entry"]
 unsafe fn __rust_entry(core: u32) -> ! {
     // first step before going any further is to clean the L1 cache to ensure there


### PR DESCRIPTION
Building on travis for the custom test framework (`ruspiro-test-framework`) and executing the final kernel in *QEMU* on travis lead to `undefined instruction` errors as the compiler added some sections in front of `.text` that contains the initial boot code.

The solution is to discard the specific sections that are not necessary for the final kernel to work:
`*.note.gnu*` is the regex that is used in the linker script to discard any matching section.