### PR TITLE
Bring core exception handling to boot crate

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[build]
+target = "aarch64-ruspiro.json"
+
+[unstable]
+build-std = ["core", "compiler_builtins", "alloc"]

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,2 @@
+# use a default of 2 spaces for indention levels
+tab_spaces = 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
-# build only master branch on commit's
+# build only development branch on commit's
 # all other branches build on PullRequest creation
 branches:
   only:
-    - master
+    - development
     - release
 
 language: rust
@@ -20,7 +20,7 @@ stages:
   - test
   - publish_dry
   - name: prepare_release
-    if: branch = master AND type != pull_request
+    if: branch = development AND type != pull_request
   - name: deploy
     if: branch = release AND type != pull_request
   - name: publish
@@ -70,11 +70,11 @@ jobs:
     - stage: prepare_release
       name: "Create PR against the release branch"
       script:
-        - 'curl -H ''Authorization: Token ''"$GIT_API_TOKEN"'''' -X POST -H ''Content-type: application/json'' --data ''{"title":"Prepare Release and crates.io publishing", "head":"master", "base":"release", "draft":false, "body":"Automatic PR to the release branch as preperation to publish the library"}'' https://api.github.com/repos/$TRAVIS_REPO_SLUG/pulls > /dev/null'
+        - 'curl -H ''Authorization: Token ''"$GIT_API_TOKEN"'''' -X POST -H ''Content-type: application/json'' --data ''{"title":"Prepare Release and crates.io publishing", "head":"development", "base":"release", "draft":false, "body":"Automatic PR to the release branch as preperation to publish the library"}'' https://api.github.com/repos/$TRAVIS_REPO_SLUG/pulls > /dev/null'
 
     - stage: deploy
       name: "Create GitHub release"
-      
+      script: echo "creating github release"
       before_deploy:
         # extract current crate version from argo.toml
         - export CRATE_VERSION=v`sed -En 's/^version.*=.*\"(.*)\".*$/\1/p' < Cargo.toml`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,9 +2,24 @@
 # It is not intended for manual editing.
 [[package]]
 name = "cc"
-version = "1.0.60"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef611cc68ff783f18535d77ddd080185275713d852c4f5cbb6122c462a7a825c"
+checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
+
+[[package]]
+name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "log"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcf3805d4480bb5b86070dcfeb9e2cb2ebc148adb753c5cca5f884d1d65a42b2"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "ruspiro-arch-aarch64"
@@ -17,9 +32,10 @@ dependencies = [
 
 [[package]]
 name = "ruspiro-boot"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "cc",
+ "log",
  "ruspiro-cache",
  "ruspiro-register",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ruspiro-boot"
 authors = ["André Borrmann <pspwizard@gmx.de>"]
-version = "0.4.2" # remember to update html_root_url
+version = "0.5.0" # remember to update html_root_url
 description = """
 Bare metal boot strapper code for the Raspberry Pi 3 to conviniently start a custom kernel within the Rust environment
 without the need to deal with all the initial setup like stack pointers, switch to the appropriate exeption level and getting all cores kicked off for processing of code compiled from Rust.
@@ -13,7 +13,9 @@ readme = "README.md"
 keywords = ["RusPiRo", "aarch64", "boot", "baremetal", "multicore"]
 categories = ["no-std", "embedded"]
 edition = "2018"
+# define a linkage name to ensure this crate is ever beeing linked once into a final binary
 links = "ruspiro_boot"
+# compile the assembler parts before the rust compiler runs on this crate
 build = "build.rs"
 exclude = [".travis.yml", "Makefile.toml"]
 
@@ -25,21 +27,21 @@ is-it-maintained-open-issues = { repository = "RusPiRo/ruspiro-boot" }
 [lib]
 
 [build-dependencies]
-cc = "1.0.59"
+cc = "~1.0"
 
 [dependencies]
-ruspiro-register = "0.5"
-ruspiro-cache = "0.4"
+log = { version = "~0.4", default-features = false }
+ruspiro-register = "~0.5"
+ruspiro-cache = "~0.4"
 
 [features]
-ruspiro_pi3 = [ ]
+# activate this feature to get multicore support 
 multicore = [ ]
 
 # ensure the required features of the crate are active for the doc.rs build
 [package.metadata.docs.rs]
 targets = ["aarch64-unknown-none", "aarch64-unknown-linux-gnu"]
 features = [
-    "ruspiro_pi3",
     "multicore"
 ]
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,60 +1,37 @@
 #***********************************************************************************************************************
 # cargo make tasks to build the example for the Raspberry Pi
 #***********************************************************************************************************************
-
-# AARCH64 specific profile environment varialbles
 [env.development]
 CC = "aarch64-none-elf-gcc"
 AR = "aarch64-none-elf-ar"
+OCOPY = "aarch64-none-elf-objcopy"
 CFLAGS = "-march=armv8-a -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53"
-RUSTFLAGS = "-C linker=${CC} -C target-cpu=cortex-a53 -C link-arg=-nostartfiles -C link-arg=-T./link64.ld"
-BUILD_TARGET = "aarch64-unknown-none"
+RUSTFLAGS = "-C target-cpu=cortex-a53 -C target-feature=+strict-align,+a53,+fp-armv8,+neon -C link-arg=-T./link64.ld"
 
-# AARCH64 specific Travis CI env. variables. "aarch64-none-elf" is not available there as it seems
 [env.travis]
 CC = "aarch64-linux-gnu-gcc"
 AR = "aarch64-linux-gnu-ar"
+OCOPY = "aarch64-linux-gnu-objcopy"
 CFLAGS = "-march=armv8-a -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53"
-RUSTFLAGS = "-C linker=${CC} -C target-cpu=cortex-a53 -C link-arg=-nostartfiles -C link-arg=-T./link64.ld"
-BUILD_TARGET = "aarch64-unknown-none"
+RUSTFLAGS = "-C target-cpu=cortex-a53 -C target-feature=+strict-align,+a53,+fp-armv8,+neon -C link-arg=-T./link64.ld"
 
-[tasks.xbuild]
+[tasks.build]
 command = "cargo"
-args = ["xbuild", "--target", "${BUILD_TARGET}", "--release", "--features", "${FEATURES}"]
-
-[tasks.pi3]
-env = { FEATURES = "ruspiro_pi3,multicore" }
-run_task = "xbuild"
+args = ["build", "--release", "--features", "${FEATURES}"]
 
 [tasks.clippy]
-env = { FEATURES = "ruspiro_pi3,multicore" }
+env = { FEATURES = "" }
 command = "cargo"
-args = ["clippy", "--target", "${BUILD_TARGET}", "--features", "${FEATURES}"]
+args = ["clippy", "--features", "${FEATURES}"]
 
 [tasks.doc]
-env = { FEATURES = "ruspiro_pi3,multicore" }
+env = { FEATURES = "" }
 command = "cargo"
-args = ["doc", "--target", "${BUILD_TARGET}", "--features", "${FEATURES}", "--open"]
+args = ["doc", "--features", "${FEATURES}", "--open"]
 
-[tasks.unittest]
-env = { FEATURES = "ruspiro_pi3,multicore" }
-command = "cargo"
-args = ["test", "--tests", "--features", "${FEATURES}"]
-
-[tasks.doctest]
-env = { FEATURES = "ruspiro_pi3,multicore" }
-command = "cargo"
-args = ["test", "--doc", "--features", "${FEATURES}"]
-
-[tasks.publish_dry]
-env = { FEATURES = "ruspiro_pi3" }
-command = "cargo"
-args = ["publish", "--dry-run", "--target", "${BUILD_TARGET}", "--features", "${FEATURES}"]
-
-[tasks.publish]
-env = { FEATURES = "ruspiro_pi3" }
-command = "cargo"
-args = ["publish", "--token", "${CRATES_TOKEN}", "--allow-dirty", "--target", "${BUILD_TARGET}", "--features", "${FEATURES}"]
+[tasks.pi3]
+env = { FEATURES = "" }
+run_task = "build"
 
 [tasks.clean]
 command = "cargo"

--- a/aarch64-ruspiro.json
+++ b/aarch64-ruspiro.json
@@ -1,0 +1,34 @@
+{
+    "arch": "aarch64",
+    "data-layout": "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128",
+    "executables": true,
+    "is-builtin": false,
+    "linker-flavor": "ld.lld",
+    "linker": "rust-lld",
+    "llvm-target": "aarch64-unknown-none",
+    "max-atomic-width": 128,
+    "os": "none",
+    "pre-link-args": {
+      "gcc": [
+        "-Wl,--as-needed",
+        "-Wl,-z,noexecstack"
+      ]
+    },
+    "target-c-int-width": "32",
+    "target-endian": "little",
+    "target-family": "unix",
+    "target-mcount": "\u0001_mcount",
+    "target-pointer-width": "64",
+    "unsupported-abis": [
+      "stdcall",
+      "fastcall",
+      "vectorcall",
+      "thiscall",
+      "win64",
+      "sysv64"
+    ],
+    "vendor": "unknown",
+    "panic-strategy": "abort",
+    "disable-redzone": true,
+    "features": ""
+  }

--- a/build.rs
+++ b/build.rs
@@ -12,24 +12,24 @@ extern crate cc;
 use std::env;
 
 fn main() {
-    let script_location = env::current_dir().unwrap();
+  let script_location = env::current_dir().unwrap();
 
-    if let Some(target_arch) = env::var_os("CARGO_CFG_TARGET_ARCH") {
-        if target_arch == "aarch64" {
-            cc::Build::new()
-                .file("src/asm/aarch64/bootstrap.S")
-                .flag("-march=armv8-a")
-                .compile("bootstrap");
-            cc::Build::new()
-                .file("src/asm/aarch64/exceptionvector.S")
-                .flag("-march=armv8-a")
-                .compile("excvector");
-            // print the linker file location of the boot crate to the env-variables
-            println!("cargo:linkerscript={}/link64.ld", script_location.display());
+  if let Some(target_arch) = env::var_os("CARGO_CFG_TARGET_ARCH") {
+    if target_arch == "aarch64" {
+      cc::Build::new()
+        .file("src/asm/aarch64/bootstrap.S")
+        .flag("-march=armv8-a")
+        .compile("bootstrap");
+      cc::Build::new()
+        .file("src/asm/aarch64/exceptionvector.S")
+        .flag("-march=armv8-a")
+        .compile("excvector");
+      // print the linker file location of the boot crate to the env-variables
+      println!("cargo:linkerscript={}/link64.ld", script_location.display());
 
-            println!("cargo:rerun-if-changed=link64.ld");
-            println!("cargo:rerun-if-changed=src/asm/aarch64/bootstrap.S");
-            println!("cargo:rerun-if-changed=src/asm/aarch64/exceptionvector.S");
-        }
+      println!("cargo:rerun-if-changed=link64.ld");
+      println!("cargo:rerun-if-changed=src/asm/aarch64/bootstrap.S");
+      println!("cargo:rerun-if-changed=src/asm/aarch64/exceptionvector.S");
     }
+  }
 }

--- a/src/asm/aarch64/exceptionvector.S
+++ b/src/asm/aarch64/exceptionvector.S
@@ -30,10 +30,8 @@
  * default exception handler that does nothing for the time beeing
  * parameter passed: type, esr, spsr, far, elr
  **************************************************************************************************/
-.weak __exception_handler_default
-__exception_handler_default:
-    nop
-    ret
+.global __exception_handler_default
+
 
 /***************************************************************************************************
  * generic exception handler trampoline

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -1,0 +1,149 @@
+/***********************************************************************************************************************
+ * Copyright (c) 2020 by the authors
+ *
+ * Author: André Borrmann <pspwizard@gmx.de>
+ * License: Apache License 2.0 / MIT
+ **********************************************************************************************************************/
+
+//! # Core exception handling
+//!
+//! Default implementation to handle exeptions that can be raised by the cores
+//!
+
+use log::*;
+
+/// The different exceptions that are handled by the exception vector configured during
+/// the initialization phase of each core
+#[allow(dead_code)]
+#[repr(u32)]
+pub enum ExceptionType {
+  CurrentElSp0Sync = 0x01,
+  CurrentElSp0Irq = 0x02,
+  CurrentElSp0Fiq = 0x03,
+  CurrentElSp0SErr = 0x04,
+
+  CurrentElSpxSync = 0x11,
+  CurrentElSpxIrq = 0x12,
+  CurrentElSpxFiq = 0x13,
+  CurrentElSpxSErr = 0x14,
+
+  LowerEl64SpxSync = 0x21,
+  LowerEl64SpxIrq = 0x22,
+  LowerEl64SpxFiq = 0x23,
+  LowerEl64SpxSErr = 0x24,
+
+  LowerEl32SpxSync = 0x31,
+  LowerEl32SpxIrq = 0x32,
+  LowerEl32SpxFiq = 0x33,
+  LowerEl32SpxSErr = 0x34,
+
+  A32UndefInstruction = 0x50,
+  A32SoftwareInterrupt = 0x51,
+  A32PrefetchAbort = 0x52,
+  A32DataAbort = 0x53,
+  A32Irq = 0x54,
+  A32Fiq = 0x55,
+}
+
+/// The default exception handler.
+/// This is the entry point for any exception taken at any core. The type gives the hint on what
+/// the exyception is about, sync, irq, etc. This entry point is called from the ``ruspiro-boot``
+/// crate when this is used for bootstrapping. Otherwise the custom bootstrapping need to properly
+/// setup the exception table and call this entry point with the required input
+///
+//#[cfg(target_arch = "aarch64")]
+#[no_mangle]
+pub unsafe extern "C" fn __exception_handler_default(
+  exception: ExceptionType,
+  esr: u64,
+  spsr: u64,
+  far: u64,
+  elr: u64,
+) {
+  match exception {
+    ExceptionType::CurrentElSpxSync => {
+      error!(
+        "Exeption - pc: {:#x}, addr: {:#x}, spsr: {:#x}",
+        elr, far, spsr
+      );
+      let esr_ec = esr >> 26;
+      warn!("esr_ec: {:#b}", esr_ec);
+      let esr_iss = esr & 0x01FF_FFFF;
+      match esr_ec {
+        0b000000 => {
+          panic!("Unknown Reason");
+        }
+        0b010001 => {
+          panic!("SVC in a32 instruction called");
+        }
+        0b010010 => {
+          panic!("HVC in a32 instruction called");
+        }
+        0b010011 => {
+          panic!("SMC in a32 instruction called");
+        }
+        0b010101 => {
+          panic!("SVC in a64 instruction called");
+        }
+        0b010110 => {
+          panic!("HVC in a64 instruction called");
+        }
+        0b010111 => {
+          panic!("SMC in a64 instruction called");
+        }
+        0b100001 => {
+          panic!("instruction abort");
+        }
+        0b100100 => {
+          panic!("data abort lower EL");
+        }
+        0b100101 => {
+          error!("Data Abort Exeption - {:#b}", esr_iss);
+          if (esr_iss & (1 << 8)) == 1 << 8 {
+            debug!("Cache Maintenance")
+          };
+          if (esr_iss & (1 << 6)) == 1 << 6 {
+            debug!("Write")
+          } else {
+            debug!("Read")
+          };
+          if (esr_iss & 0x3F) == 0b000100 {
+            debug!("Translation Level 0")
+          };
+          if (esr_iss & 0x3F) == 0b000101 {
+            debug!("Translation Level 1")
+          };
+          if (esr_iss & 0x3F) == 0b000110 {
+            debug!("Translation Level 2")
+          };
+          if (esr_iss & 0x3F) == 0b000111 {
+            debug!("Translation Level 3")
+          };
+          if (esr_iss & 0x3F) == 0b100001 {
+            debug!("Alignment Fault - FAR {:#x} - ELR {:#x}", far, elr)
+          };
+          panic!("data abort same EL");
+        }
+        0b111100 => {
+          // this is a BRK instruction used for endless loops, so just silently ignore
+          // and halt here
+          info!("BRK instruction");
+          loop {}
+        }
+        _ => panic!("unhandled sync exception"),
+      }
+    }
+    ExceptionType::CurrentElSp0Irq => __isr_default(),
+    ExceptionType::CurrentElSp0Fiq => __isr_default(),
+    ExceptionType::CurrentElSpxIrq => __isr_default(),
+    ExceptionType::CurrentElSpxFiq => __isr_default(),
+    _ => error!("unhandled exeption"),
+  }
+}
+
+/// Provide a waek linked default interrupt service routine.
+/// As soon as any other crate (e.g. `ruspiro-interrupt`) is linked with this one
+/// the linkage will be overruled with the proper implementation.
+#[linkage = "weak"]
+#[no_mangle]
+extern "C" fn __isr_default() {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
  * License: Apache License 2.0 / MIT
  **********************************************************************************************************************/
 #![doc(html_root_url = "https://docs.rs/ruspiro-boot/||VERSION||")]
-#![cfg_attr(not(any(test, doctest)), no_std)]
+#![no_std]
 #![feature(llvm_asm, lang_items, linkage)]
 // this crate does only compile with valid content if the target architecture is AARCH64!
 #![cfg(target_arch = "aarch64")]
@@ -14,6 +14,12 @@
 //!
 //! This crates provides the startup routines that are needed to be run from a baremetal kernel on
 //! the RaspberryPi before execution could be handed over to Rust code.
+//! 
+//! The crate is only valid when compiled for the
+//! target architecture **aarch64**. However, event though this crate might be compiled for this target architecture it
+//! is tailor made for the Raspberry Pi 3. This crate may be used in other contexts at your own risk. To build your own
+//! Raspberry Pi bare metal kernel or operating system please use the
+//! [RusPiRo Turorials](https://github.com/RusPiRo/ruspiro-tutorials) as a starting point.
 //!
 //! # Usage
 //!
@@ -36,22 +42,15 @@
 //! }
 //! ```
 //!
-//! The bootstrapper requires specific symbols to be known to the linker to be able to build the
-//! final binary. To use the linker script that is provided as part of this crate in
-//! your own rust binary crate you could either copy them manually from the git repository based on
-//! your desired target architecture for the build:
-//! [aarch64 linker script](https://github.com/RusPiRo/ruspiro-boot/blob/v||VERSION||/link64.ld)
-//!
 //! # Features
 //!
 //! Feature         | Description
 //! ----------------|------------------------------------------------------------------------------
-//! ``ruspiro_pi3`` | Passed to dependent crates to ensure  proper MMIO base memory address for Raspberry Pi 3 when accessing the peripherals
-//! ``multicore``  | Enables the compilation of the multi core boot sequence. Without it only the main core 0 is running.
+//! ``multicore``   | Enables the compilation of the multi core boot sequence. Without it only the main core 0 is running.
 //!
 //! ## Hint:
 //! To successfully build a bare metal binary/kernel that depends on this one to perform the boot
-//! strapping part it is **highly recomended** to use the linker script [link64.ld](link64.ld) provided by this crate.
+//! strapping part it is **highly recomended** to use the linker script [link64.ld](https://github.com/RusPiRo/ruspiro-boot/blob/v||VERSION||/link64.ld) provided by this crate.
 //! To conviniently refer to the linker scripts contained in this crate it's recommended to use a
 //! specific build script in your project that copies the required file to your current project
 //! folder and could then be referred to with the `RUSTFLAG` parameter `-C link-arg=-T./link64.ld`.
@@ -83,19 +82,20 @@
 //! To get started you could check out the template projects [here](https://www.github.com/RusPiRo/ruspiro_templates)
 //!
 
-use core::ptr;
-use ruspiro_cache as cache;
+mod exception;
 pub mod macros;
+
 pub use self::macros::*;
+use ruspiro_cache as cache;
 
 // TODO: verify if the stubs are really required
 //#[cfg(not(any(test, doctest)))]
 //mod stubs;
 
 extern "C" {
-    fn __kernel_startup(core: u32);
-    fn __kernel_run(core: u32) -> !;
-    fn __boot();
+  fn __kernel_startup(core: u32);
+  fn __kernel_run(core: u32) -> !;
+  fn __boot();
 }
 
 /// Entry point that is called by the bootstrapping code.
@@ -106,42 +106,41 @@ extern "C" {
 ///
 #[export_name = "__rust_entry"]
 unsafe fn __rust_entry(core: u32) -> ! {
-    // first step before going any further is to clean the L1 cache to ensure there
-    // is no garbage remaining that could impact actual execution once the cache is enabled.
-    cache::invalidate_dcache();
+  // first step before going any further is to clean the L1 cache to ensure there
+  // is no garbage remaining that could impact actual execution once the cache is enabled.
+  cache::invalidate_dcache();
 
-    // jump to the function provided by the user of this crate
-    #[cfg(not(test))]
-    __kernel_startup(core);
+  // jump to the function provided by the user of this crate
+  #[cfg(not(test))]
+  __kernel_startup(core);
 
-    // once the one-time startup of this core has been done kickoff any other core
-    #[cfg(feature = "multicore")]
-    kickoff_next_core(core);
+  // once the one-time startup of this core has been done kickoff any other core
+  #[cfg(feature = "multicore")]
+  kickoff_next_core(core);
 
-    // after the one time setup enter the processing loop
-    #[cfg(not(test))]
-    __kernel_run(core);
+  // after the one time setup enter the processing loop
+  #[cfg(not(test))]
+  __kernel_run(core);
 
-    #[cfg(test)]
-    loop {}
+  #[cfg(test)]
+  loop {}
 }
-
 
 #[cfg(feature = "multicore")]
 fn kickoff_next_core(core: u32) {
-    // kicking of another core in arch64 means, writing the jump address for this
-    // core into a specific memory location
-    let jump_store: u64 = match core {
-        0 => 0xe0,
-        1 => 0xe8,
-        2 => 0xf0,
-        _ => return,
-    };
-    unsafe {
-        ptr::write_volatile(jump_store as *mut u64, 0x80000); //__boot as *const () as u64);
-        // as this core may have caches enabled, flush it so the other core
-        // sees the correct data on memory and the write does not only hit the cache
-        cache::flush_dcache_range(0xe0, 0x10);
-        llvm_asm!("sev"); // trigger an event to wake up the sleeping cores
-    }
+  // kicking of another core in arch64 means, writing the jump address for this
+  // core into a specific memory location
+  let jump_store: u64 = match core {
+    0 => 0xe0,
+    1 => 0xe8,
+    2 => 0xf0,
+    _ => return,
+  };
+  unsafe {
+    ptr::write_volatile(jump_store as *mut u64, 0x80000); //__boot as *const () as u64);
+                                                          // as this core may have caches enabled, flush it so the other core
+                                                          // sees the correct data on memory and the write does not only hit the cache
+    cache::flush_dcache_range(0xe0, 0x10);
+    llvm_asm!("sev"); // trigger an event to wake up the sleeping cores
+  }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -12,8 +12,8 @@
 
 /// Use this macro to define the your custom one-time-initialization entry point function to be used once the mandatory
 /// boot process has finished and the processing is handed over to the high level rust code. As each core will come
-/// alive **one after another**, this function is called with the core id/number it's running on. The next core comes 
-/// alive after the actual one finished processing this function, it is guaranteed that the cores will come alive in 
+/// alive **one after another**, this function is called with the core id/number it's running on. The next core comes
+/// alive after the actual one finished processing this function, it is guaranteed that the cores will come alive in
 /// sequence!
 ///
 /// # Example
@@ -27,15 +27,15 @@
 /// ```
 #[macro_export]
 macro_rules! come_alive_with {
-    ($path:path) => {
-        // in this case the macro expends to an library export symbol called __kernel_startup
-        // this function is called from the boot up sequence
-        #[export_name = "__kernel_startup"]
-        pub fn __entry(core: u32) {
-            let entry_f: fn(u32) = $path;
-            entry_f(core);
-        }
-    };
+  ($path:path) => {
+    // in this case the macro expends to an library export symbol called __kernel_startup
+    // this function is called from the boot up sequence
+    #[export_name = "__kernel_startup"]
+    pub fn __entry(core: u32) {
+      let entry_f: fn(u32) = $path;
+      entry_f(core);
+    }
+  };
 }
 
 /// Use this macro to define the never-returning processing entry point function to be used for the processing
@@ -53,14 +53,14 @@ macro_rules! come_alive_with {
 /// ```
 #[macro_export]
 macro_rules! run_with {
-    // macro used with a path given to it matches this branch
-    ($path:path) => {
-        // in this case the macro expends to an library export symbol called __kernel_run
-        // this function is called from the boot up sequence
-        #[export_name = "__kernel_run"]
-        pub fn __run_loop(core: u32) {
-            let run_f: fn(u32) -> ! = $path;
-            run_f(core);
-        }
-    };
+  // macro used with a path given to it matches this branch
+  ($path:path) => {
+    // in this case the macro expends to an library export symbol called __kernel_run
+    // this function is called from the boot up sequence
+    #[export_name = "__kernel_run"]
+    pub fn __run_loop(core: u32) {
+      let run_f: fn(u32) -> ! = $path;
+      run_f(core);
+    }
+  };
 }


### PR DESCRIPTION
The exception vector table was already part of the boot crate but the implementation was delegated to e.g. the interrupt crate. However, the interrupt crate shall only be dealing with interrupts but not with all other exceptions as well (eg. aborts, SVC, HVC calls). Thus the boot crate now implements the basic exception handling and delegates only the interrupt handling to an external crate e.g. the interrupt crate.

The external crate requires to implement and export a function called `__isr_default`. The function has no parameters.

