### PR TITLE
Introduce the custom build target

### DIFF
--- a/.cargo/aarch64-ruspiro.json
+++ b/.cargo/aarch64-ruspiro.json
@@ -1,0 +1,34 @@
+{
+    "arch": "aarch64",
+    "data-layout": "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128",
+    "executables": true,
+    "is-builtin": false,
+    "linker-flavor": "ld.lld",
+    "linker": "rust-lld",
+    "llvm-target": "aarch64-unknown-none",
+    "max-atomic-width": 128,
+    "os": "none",
+    "pre-link-args": {
+      "gcc": [
+        "-Wl,--as-needed",
+        "-Wl,-z,noexecstack"
+      ]
+    },
+    "target-c-int-width": "32",
+    "target-endian": "little",
+    "target-family": "unix",
+    "target-mcount": "\u0001_mcount",
+    "target-pointer-width": "64",
+    "unsupported-abis": [
+      "stdcall",
+      "fastcall",
+      "vectorcall",
+      "thiscall",
+      "win64",
+      "sysv64"
+    ],
+    "vendor": "unknown",
+    "panic-strategy": "abort",
+    "disable-redzone": true,
+    "features": ""
+  }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           profile: minimal
           toolchain: nightly
           override: true
-          components: rustfmt, clippy, rust-src, llvm-tools-preview
+          components: rust-src, llvm-tools-preview
           target: aarch64-unknown-none
 
       - name: Install Cargo Make
@@ -64,7 +64,7 @@ jobs:
           profile: minimal
           toolchain: nightly
           override: true
-          components: rustfmt, clippy, rust-src, llvm-tools-preview
+          components: rust-src, llvm-tools-preview
           target: aarch64-unknown-none
 
       - name: Install Cargo Make
@@ -153,7 +153,7 @@ jobs:
           profile: minimal
           toolchain: nightly
           override: true
-          components: rustfmt, clippy, rust-src, llvm-tools-preview
+          components: rust-src, llvm-tools-preview
           target: aarch64-unknown-none
 
       - name: Install Cargo Make

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-/target
+**/*target
 **/*.rs.bk
-**/release
 .vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 # Changelog
 
+## :cat: v0.5.2
+
+Introduce the custom build target `aarch64-ruspiro` to the crate. This version also introduces an example folder (this is nmot published to crates.io) that contains a minimalistic Raspberry Pi 3 baremetal kernel using this boot crate.
+
 ## :cat: v0.5.1
 
 Migrate the actual travis-ci build pipeline to github actions
 
 ## :cat: v0.5.0
 
-Incorporate the basic excpetion handling within the boot loading crate instead of delegating the whole stuff to the `ruspiro-interrupt` crate. Now only the interrupt and fast-interrupt related exeptions will be delegated to an external crate that implements and exports this function: `extern "C" fn __isr_default() {}`.
+Incorporate the basic exception handling within the boot loading crate instead of delegating the whole stuff to the `ruspiro-interrupt` crate. Now only the interrupt and fast-interrupt related exeptions will be delegated to an external crate that implements and exports this function: `extern "C" fn __isr_default() {}`.
 
 - ### :bulb: Features
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,8 @@ dependencies = [
 [[package]]
 name = "ruspiro-arch-aarch64"
 version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "487585439e7a06c60294325fd1016cf5841ecf39bc388088d7fe09938a5e8050"
 dependencies = [
  "ruspiro-register",
 ]
@@ -52,3 +54,4 @@ dependencies = [
 [[package]]
 name = "ruspiro-register"
 version = "0.5.4"
+source = "git+https://github.com/RusPiRo/ruspiro-register.git?branch=development#455ccee004af3c0b13136fd993277d13c6ac8949"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,5 @@ features = [
 ]
 
 [patch.crates-io]
-ruspiro-register = { path = "../ruspiro-register" }
-ruspiro-arch-aarch64 = { path = "../ruspiro-arch-aarch64" }
-#ruspiro-register = { git = "https://github.com/RusPiRo/ruspiro-register.git", branch = "development" }
+ruspiro-register = { git = "https://github.com/RusPiRo/ruspiro-register.git", branch = "development" }
 ruspiro-cache = { git = "https://github.com/RusPiRo/ruspiro-cache.git", branch = "development" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "ruspiro-boot"
 authors = ["André Borrmann <pspwizard@gmx.de>"]
-version = "0.5.1" # remember to update html_root_url
+version = "0.5.2" # remember to update html_root_url
 description = """
 Bare metal boot strapper code for the Raspberry Pi 3 to conviniently start a custom kernel within the Rust environment
 without the need to deal with all the initial setup like stack pointers, switch to the appropriate exeption level and getting all cores kicked off for processing of code compiled from Rust.
 """
-license = "Apache-2.0"
+license = "Apache-2.0 OR MIT"
 repository = "https://github.com/RusPiRo/ruspiro-boot/tree/v||VERSION||"
 documentation = "https://docs.rs/ruspiro-boot/||VERSION||"
 readme = "README.md"
@@ -17,7 +17,7 @@ edition = "2018"
 links = "ruspiro_boot"
 # compile the assembler parts before the rust compiler runs on this crate
 build = "build.rs"
-exclude = [".travis.yml", "Makefile.toml"]
+exclude = ["Makefile.toml", ".cargo/config.toml", "examples"]
 
 [badges]
 maintenance = { status = "actively-developed" }
@@ -28,9 +28,9 @@ maintenance = { status = "actively-developed" }
 cc = "~1.0"
 
 [dependencies]
-log = { version = "~0.4", default-features = false }
-ruspiro-register = "~0.5"
-ruspiro-cache = "~0.4"
+log = { version = "~0.4.14", default-features = false }
+ruspiro-register = "~0.5.4"
+ruspiro-cache = "~0.4.1"
 
 [features]
 # activate this feature to get multicore support 
@@ -38,11 +38,13 @@ multicore = [ ]
 
 # ensure the required features of the crate are active for the doc.rs build
 [package.metadata.docs.rs]
-targets = ["aarch64-unknown-none", "aarch64-unknown-linux-gnu"]
+default-target = "aarch64-unknown-linux-gnu"
 features = [
     "multicore"
 ]
 
 [patch.crates-io]
-ruspiro-register = { git = "https://github.com/RusPiRo/ruspiro-register.git", branch = "master" }
-ruspiro-cache = { git = "https://github.com/RusPiRo/ruspiro-cache.git", branch = "master" }
+ruspiro-register = { path = "../ruspiro-register" }
+ruspiro-arch-aarch64 = { path = "../ruspiro-arch-aarch64" }
+#ruspiro-register = { git = "https://github.com/RusPiRo/ruspiro-register.git", branch = "development" }
+ruspiro-cache = { git = "https://github.com/RusPiRo/ruspiro-cache.git", branch = "development" }

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -27,9 +27,23 @@ env = { FEATURES = "" }
 command = "cargo"
 args = ["doc", "--features", "${FEATURES}", "--open"]
 
-[tasks.pi3]
+[tasks.test]
+env = { FEATURES = "" }
+command = "cargo"
+args = ["test", "--features", "${FEATURES}"]
+
+[tasks.pi3_singlecore]
 env = { FEATURES = "" }
 run_task = "build"
+dependencies = ["clean"]
+
+[tasks.pi3_multicore]
+env = { FEATURES = "multicore" }
+run_task = "build"
+dependencies = ["clean"]
+
+[tasks.pi3]
+dependencies = ["pi3_singlecore", "pi3_multicore"]
 
 [tasks.clean]
 command = "cargo"

--- a/examples/minimal/.cargo/aarch64-ruspiro.json
+++ b/examples/minimal/.cargo/aarch64-ruspiro.json
@@ -1,0 +1,34 @@
+{
+    "arch": "aarch64",
+    "data-layout": "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128",
+    "executables": true,
+    "is-builtin": false,
+    "linker-flavor": "ld.lld",
+    "linker": "rust-lld",
+    "llvm-target": "aarch64-unknown-none",
+    "max-atomic-width": 128,
+    "os": "none",
+    "pre-link-args": {
+      "gcc": [
+        "-Wl,--as-needed",
+        "-Wl,-z,noexecstack"
+      ]
+    },
+    "target-c-int-width": "32",
+    "target-endian": "little",
+    "target-family": "unix",
+    "target-mcount": "\u0001_mcount",
+    "target-pointer-width": "64",
+    "unsupported-abis": [
+      "stdcall",
+      "fastcall",
+      "vectorcall",
+      "thiscall",
+      "win64",
+      "sysv64"
+    ],
+    "vendor": "unknown",
+    "panic-strategy": "abort",
+    "disable-redzone": true,
+    "features": ""
+  }

--- a/examples/minimal/.cargo/config.toml
+++ b/examples/minimal/.cargo/config.toml
@@ -1,0 +1,5 @@
+[build]
+target = "aarch64-ruspiro.json"
+
+[unstable]
+build-std = ["core", "compiler_builtins", "alloc"]

--- a/examples/minimal/Cargo.lock
+++ b/examples/minimal/Cargo.lock
@@ -3,6 +3,14 @@
 version = 3
 
 [[package]]
+name = "boot-example"
+version = "0.0.1"
+dependencies = [
+ "cc",
+ "ruspiro-boot",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -26,6 +34,8 @@ dependencies = [
 [[package]]
 name = "ruspiro-arch-aarch64"
 version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "487585439e7a06c60294325fd1016cf5841ecf39bc388088d7fe09938a5e8050"
 dependencies = [
  "ruspiro-register",
 ]
@@ -43,7 +53,8 @@ dependencies = [
 [[package]]
 name = "ruspiro-cache"
 version = "0.4.1"
-source = "git+https://github.com/RusPiRo/ruspiro-cache.git?branch=development#d950d9b259af78029167fc0341c4afa82eff8ca7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ebe25a7a5c319cf5a58f368c5bc0dd3a672e4a66d0d86382194a28bc9ad92f1"
 dependencies = [
  "cc",
  "ruspiro-arch-aarch64",
@@ -52,3 +63,5 @@ dependencies = [
 [[package]]
 name = "ruspiro-register"
 version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "161d5f7992ad812a4cf78301846265fb34ba86db288d17aa35d36c5ec72ee349"

--- a/examples/minimal/Cargo.toml
+++ b/examples/minimal/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "boot-example"
+authors = ["André Borrmann <pspwizard@gmx.de>"]
+version = "0.0.1"
+edition = "2018"
+
+[[bin]]
+name = "kernel"
+path = "./src/main.rs"
+
+[build-dependencies]
+cc = "~1.0"
+
+[dependencies]
+ruspiro-boot = { path = "../../", features = ["multicore"] }

--- a/examples/minimal/Makefile.toml
+++ b/examples/minimal/Makefile.toml
@@ -1,0 +1,41 @@
+#***********************************************************************************************************************
+# cargo make tasks to build the example for the Raspberry Pi
+#***********************************************************************************************************************
+[env.development]
+CC = "aarch64-none-elf-gcc"
+AR = "aarch64-none-elf-ar"
+CFLAGS = "-march=armv8-a -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53"
+RUSTFLAGS = "-C target-cpu=cortex-a53 -C target-feature=+strict-align,+a53,+fp-armv8,+neon -C link-arg=-T./link64.ld"
+
+[tasks.build]
+command = "cargo"
+args = ["build", "--release", "--features", "${FEATURES}"]
+
+[tasks.kernel]
+command = "aarch64-none-elf-objcopy"
+args = ["-O", "binary", "./target/aarch64-ruspiro/release/kernel", "./target/kernel8.img"]
+dependencies = [
+    "build"
+]
+
+[tasks.pi3]
+env = { FEATURES = "" }
+run_task = "kernel"
+
+[tasks.qemu]
+command = "qemu-system-aarch64"
+args = ["-M", "raspi3", "-kernel", "./target/kernel8.img", "-nographic", "-serial", "null", "-serial", "mon:stdio",  "-d", "int,mmu", "-D", "qemu.log"]
+dependencies = [
+    "pi3"
+]
+
+[tasks.deploy]
+command = "cargo"
+args = ["ruspiro-push", "-k", "./target/kernel8.img", "-p", "COM3"]
+dependencies = [
+    "pi3"
+]
+
+[tasks.clean]
+command = "cargo"
+args = ["clean"]

--- a/examples/minimal/aarch64-ruspiro.json
+++ b/examples/minimal/aarch64-ruspiro.json
@@ -1,0 +1,34 @@
+{
+    "arch": "aarch64",
+    "data-layout": "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128",
+    "executables": true,
+    "is-builtin": false,
+    "linker-flavor": "ld.lld",
+    "linker": "rust-lld",
+    "llvm-target": "aarch64-unknown-none",
+    "max-atomic-width": 128,
+    "os": "none",
+    "pre-link-args": {
+      "gcc": [
+        "-Wl,--as-needed",
+        "-Wl,-z,noexecstack"
+      ]
+    },
+    "target-c-int-width": "32",
+    "target-endian": "little",
+    "target-family": "unix",
+    "target-mcount": "\u0001_mcount",
+    "target-pointer-width": "64",
+    "unsupported-abis": [
+      "stdcall",
+      "fastcall",
+      "vectorcall",
+      "thiscall",
+      "win64",
+      "sysv64"
+    ],
+    "vendor": "unknown",
+    "panic-strategy": "abort",
+    "disable-redzone": true,
+    "features": ""
+  }

--- a/examples/minimal/build.rs
+++ b/examples/minimal/build.rs
@@ -1,0 +1,28 @@
+/***************************************************************************************************
+ * Copyright (c) 2019 by the authors
+ *
+ * Author: André Borrmann
+ * License: Apache License 2.0
+ **************************************************************************************************/
+//! Build Script to copy the required linker script from the dependent `ruspiro-boot` crate to the
+//! current build folder
+//!
+
+use std::{env, fs, path::Path};
+
+fn main() {
+    // copy the linker script from the boot crate to the current directory
+    // so it will be invoked by the linker
+    if let Some(source) = env::var_os("DEP_RUSPIRO_BOOT_LINKERSCRIPT") {
+        println!("found boot dependency");
+        let ld_source = source.to_str().unwrap().replace("\\", "/");
+        let src_file = Path::new(&ld_source);
+        let trg_file = format!(
+            "{}/{}",
+            env::current_dir().unwrap().display(),
+            src_file.file_name().unwrap().to_str().unwrap()
+        );
+        println!("Copy linker script from {:?}, to {:?}", src_file, trg_file);
+        fs::copy(src_file, trg_file).unwrap();
+    }
+}

--- a/examples/minimal/link64.ld
+++ b/examples/minimal/link64.ld
@@ -1,0 +1,76 @@
+/***********************************************************************************************************************
+ * linker script to define memory addresse / sections and symbols of the binary to be build
+ * known constraints:
+ * Entry point address need to be 0x80000 in 64bit mode, the binarry is not allowed to start prior to this address
+ * Stack pointer need to be at least 8Bit and heap pointer 16Bit aligned
+ *
+ * Copyright (c) 2019 by the authors
+ *
+ * Author: André Borrmann
+ * License: Apache License 2.0
+ **********************************************************************************************************************/
+
+ENTRY(__boot)
+
+SECTIONS
+{
+	/* start memory address for RPi modules in RAM in 64bit mode*/
+	. = 0x80000;
+	    
+    .text : { KEEP(*(.text.boot)) *(.text*) }
+    .rodata : { *(.rodata*) }
+	. = ALIGN(8);
+    .init_array : {
+		__init_start = .;
+		*(.init_array)
+		*(.init_array.*)
+		__init_end = .;
+	}
+    /* bss section, contains all static variables of the c code */
+    .bss : { 
+    	__bss_start__ = .;
+    	*(.bss*)
+    	*(COMMON)
+    	__bss_end__ = .;
+    }
+	PROVIDE(_data = .);
+    .data : { *(.data*) }
+
+	/* fill the binary to always have an aligned binary size - needed for the bootloader on RPi to work properly */
+	.fill : {
+		FILL(0xDEADBEEF)
+		. += 1;
+		. = ALIGN(64) - 1;
+		BYTE(0xAA) 
+	}
+
+	/* after the code the stack pointers will start */
+	/* they cannot start from the end of usable memory as the memory */
+	/* is split betwean arm cpu and gpu and the gpu memory size is not known during compile time */
+	. = ALIGN(16);
+	__stack_end__ = .;
+	. += 0x10000;
+	__stack_top_core3__ = .;
+	. += 0x10000;
+	__stack_top_core2__ = .;
+	. += 0x10000;
+	__stack_top_core1__ = .;
+	. += 0x01000; /* stack space EL2 mode 4kB - stack goes backwards from memory end towards begin*/
+	__stack_top_EL2__ = .;
+	. += 0x0E000;
+	__stack_top_EL1__ = .;
+	. += 0x01000;
+	__stack_top_EL0__ = .;
+	__stack_top_core0__ = .;
+	__stack_top__ = .;
+	/* the heap memory address space starts where the executable and the static variables ends (aligned to 4kB to fit into MMU page)*/
+    . = ALIGN(4096);
+	__heap_start = .;
+    /* heap end is defined by the usage split of arm/gpu - set this to a fixed value for the time beeing */
+	__heap_end = 0x3E000000;
+
+	/DISCARD/ :
+	{
+		*(.note.gnu*)
+	}
+}

--- a/examples/minimal/src/main.rs
+++ b/examples/minimal/src/main.rs
@@ -1,0 +1,20 @@
+//! # Minimal example that should compile
+//!
+
+#![no_std]
+#![no_main]
+
+#[macro_use]
+extern crate ruspiro_boot;
+
+come_alive_with!(alive);
+run_with!(running);
+
+fn alive(_core: u32) {
+    // do one-time initialization here
+}
+
+fn running(_core: u32) -> ! {
+    // do any processing here and ensure you never return from this function
+    loop {}
+}

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -47,7 +47,7 @@ pub enum ExceptionType {
 
 /// The default exception handler.
 /// This is the entry point for any exception taken at any core. The type gives the hint on what
-/// the exyception is about, sync, irq, etc. This entry point is called from the ``ruspiro-boot``
+/// the exception is about, sync, irq, etc. This entry point is called from the ``ruspiro-boot``
 /// crate when this is used for bootstrapping. Otherwise the custom bootstrapping need to properly
 /// setup the exception table and call this entry point with the required input
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //!
 //! This crates provides the startup routines that are needed to be run from a baremetal kernel on
 //! the RaspberryPi before execution could be handed over to Rust code.
-//! 
+//!
 //! The crate is only valid when compiled for the
 //! target architecture **aarch64**. However, event though this crate might be compiled for this target architecture it
 //! is tailor made for the Raspberry Pi 3. This crate may be used in other contexts at your own risk. To build your own
@@ -83,9 +83,12 @@
 //!
 
 mod exception;
-pub mod macros;
+mod macros;
+mod panic;
 
 pub use self::macros::*;
+#[cfg(feature = "multicore")]
+use core::ptr;
 use ruspiro_cache as cache;
 
 // TODO: verify if the stubs are really required

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -1,0 +1,40 @@
+/***********************************************************************************************************************
+ * Copyright (c) 2020 by the authors
+ *
+ * Author: André Borrmann
+ * License: Apache License 2.0
+ **********************************************************************************************************************/
+
+//! # Panic Handler
+//!
+//! Minimalistic panic handler implementation
+//!
+
+use core::panic::PanicInfo;
+use log::error;
+
+#[cfg(not(test))]
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+  // Panicing means we have reach a situation we are unable to recover from into a valid state.
+  // Halt the panicing core and safely do nothing!
+  // The error will be printed using the log crate. It requires a global logger to be configure
+  // otherwise the output is just going no-where. Refer to the ruspiro-console crate which provides
+  // the functionality to setup a global logger
+  if let Some(location) = info.location() {
+    error!(
+      "PANIC at {:?}, {}:{}",
+      location.file(),
+      location.line(),
+      location.column()
+    );
+  } else {
+    error!("PANIC somewhere!");
+  }
+  loop {}
+}
+
+#[lang = "eh_personality"]
+fn eh_personality() {
+  // for the time beeing - nothing to be done in this function as the usecase is a bit unclear
+}


### PR DESCRIPTION
Introduce the custom build target `aarch64-ruspiro` for individual crate builds.

Add an examples folder that contains a minimalistic bare metal kernel for the Raspberry Pi3 to demonstrate usage of this crate. This folder is not uploaded to crates.io.