### PR TITLE
don't build assembly in doc.rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## :dog: v0.5.3
+
+This release aims to fix the build issue on doc.rs while the crate is uploaded to crates.io
+
+- ### :wrench: Maintenance
+
+  Disable building of the assembly on doc.rs within the build script.
+
 ## :cat: v0.5.2
 
 Introduce the custom build target `aarch64-ruspiro` to the crate. This version also introduces an example folder (this is nmot published to crates.io) that contains a minimalistic Raspberry Pi 3 baremetal kernel using this boot crate.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "ruspiro-boot"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "cc",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ruspiro-boot"
 authors = ["André Borrmann <pspwizard@gmx.de>"]
-version = "0.5.2" # remember to update html_root_url
+version = "0.5.3" # remember to update html_root_url
 description = """
 Bare metal boot strapper code for the Raspberry Pi 3 to conviniently start a custom kernel within the Rust environment
 without the need to deal with all the initial setup like stack pointers, switch to the appropriate exeption level and getting all cores kicked off for processing of code compiled from Rust.

--- a/build.rs
+++ b/build.rs
@@ -15,7 +15,7 @@ fn main() {
   let script_location = env::current_dir().unwrap();
 
   if let Some(target_arch) = env::var_os("CARGO_CFG_TARGET_ARCH") {
-    if target_arch == "aarch64" {
+    if target_arch == "aarch64" && env::var("DOCS_RS").is_err() {
       cc::Build::new()
         .file("src/asm/aarch64/bootstrap.S")
         .flag("-march=armv8-a")

--- a/examples/minimal/Cargo.lock
+++ b/examples/minimal/Cargo.lock
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "ruspiro-boot"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "cc",
  "log",


### PR DESCRIPTION
Dont build assembly code on doc.rs to prevent build issues while generating the documentation. The assembly part is not required for the doc generation.